### PR TITLE
removed http from the linked sheets

### DIFF
--- a/resume.template
+++ b/resume.template
@@ -7,8 +7,8 @@
 
 	<title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
 
-	<link href="http://bootswatch.com/lumen/bootstrap.min.css" rel="stylesheet">
-	<link href='http://fonts.googleapis.com/css?family=Roboto:500,300' rel='stylesheet' type='text/css'>
+	<link href="//bootswatch.com/lumen/bootstrap.min.css" rel="stylesheet">
+	<link href='//fonts.googleapis.com/css?family=Roboto:500,300' rel='stylesheet' type='text/css'>
 	<style>
 	{{{css}}}
 	</style>


### PR DESCRIPTION
I removed the http from the linked sheet. Some sites may reject and not load http content if the site was accessed over https. `//example.com/test.css` is equivalent to `http://example.com/test.css` if the original site was accessed unencrypted and `https://example.com/test.css`
