### PR TITLE
Allow both http and https protocols

### DIFF
--- a/resume.template
+++ b/resume.template
@@ -7,8 +7,8 @@
 
 	<title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
 
-	<link href="http://bootswatch.com/lumen/bootstrap.min.css" rel="stylesheet">
-	<link href='http://fonts.googleapis.com/css?family=Roboto:500,300' rel='stylesheet' type='text/css'>
+	<link href="//bootswatch.com/lumen/bootstrap.min.css" rel="stylesheet">
+	<link href='//fonts.googleapis.com/css?family=Roboto:500,300' rel='stylesheet' type='text/css'>
 	<style>
 	{{{css}}}
 	</style>


### PR DESCRIPTION
The use of '//' in place of 'http://' permits to use the same protocol that was used to retrieve the page.
This way, if the page is served via https, the resources will be fetched via https, and will not trigger a warning in the browser by fetching resources via unsecured connection.