### PR TITLE
Fix bootswatch url

### DIFF
--- a/resume.template
+++ b/resume.template
@@ -7,7 +7,7 @@
 
 	<title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
 
-	<link href="http://bootswatch.com/lumen/bootstrap.min.css" rel="stylesheet">
+	<link href="http://bootswatch.com/3/lumen/bootstrap.min.css" rel="stylesheet">
 	<link href='http://fonts.googleapis.com/css?family=Roboto:500,300' rel='stylesheet' type='text/css'>
 	<style>
 	{{{css}}}


### PR DESCRIPTION
The url http://bootswatch.com/lumen/bootstrap.min.css is not valid anymore, and it was replaced by http://bootswatch.com/3/lumen/bootstrap.min.css